### PR TITLE
Replace the deprecated dzil plugin

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -24,7 +24,7 @@ Acme::MetaSyntactic = 1.000
 [Prereqs / Recommends]
 Task::MetaSyntactic =
 
-[ReportVersions::Tiny]
+[Test::ReportPrereqs]
 
 [MetaResources]
 repository.web    = http://github.com/book/Data-Faker-MetaSyntactic


### PR DESCRIPTION
Replace ReportVersions::Tiny with Test::ReportPrereqs as recommended
in its own documentation.